### PR TITLE
feat: Add Roaster DB model & In Memory Repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM adoptopenjdk/openjdk11-openj9:jdk-11.0.6_10_openj9-0.18.1-alpine-slim as bu
 WORKDIR /app
 COPY . ./
 
-RUN ./gradlew build
+RUN ./gradlew build shadowJar
 
 FROM adoptopenjdk/openjdk11-openj9:jre-11.0.6_10_openj9-0.18.1-alpine as release
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,17 +31,35 @@ dependencies {
     implementation "javax.annotation:javax.annotation-api"
     implementation "io.micronaut:micronaut-http-server-netty"
     implementation "io.micronaut:micronaut-http-client"
+
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.9.8"
+    // Required to work with Java 8 Time objects
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.8"
+
     kapt platform("io.micronaut:micronaut-bom:$micronautVersion")
     kapt "io.micronaut:micronaut-inject-java"
     kapt "io.micronaut:micronaut-validation"
     kaptTest platform("io.micronaut:micronaut-bom:$micronautVersion")
     kaptTest "io.micronaut:micronaut-inject-java"
-    runtimeOnly "com.fasterxml.jackson.module:jackson-module-kotlin:2.9.8"
     runtimeOnly "ch.qos.logback:logback-classic:1.2.3"
     testImplementation platform("io.micronaut:micronaut-bom:$micronautVersion")
     testImplementation "io.micronaut.test:micronaut-test-kotlintest"
     testImplementation "io.mockk:mockk:1.9.3"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.3.2"
+
+    // AssertK
+    testCompile 'com.willowtreeapps.assertk:assertk-jvm:0.22'
+
+    // Spek
+    testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
+    testImplementation ("org.spekframework.spek2:spek-dsl-jvm:$spekVersion") {
+        exclude group: 'org.jetbrains.kotlin'
+    }
+    testRuntimeOnly ("org.spekframework.spek2:spek-runner-junit5:$spekVersion") {
+        exclude group: 'org.junit.platform'
+        exclude group: 'org.jetbrains.kotlin'
+    }
+    testRuntimeOnly "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 }
 
 test.classpath += configurations.developmentOnly
@@ -50,6 +68,7 @@ mainClassName = "com.coffeeculture.Application"
 
 test {
     useJUnitPlatform()
+    testLogging.events("passed", "skipped", "failed")
 }
 
 allOpen {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 micronautVersion=1.3.4
 kotlinVersion=1.3.72
+spekVersion=2.0.9

--- a/src/main/kotlin/com/coffeeculture/Application.kt
+++ b/src/main/kotlin/com/coffeeculture/Application.kt
@@ -7,7 +7,7 @@ object Application {
     @JvmStatic
     fun main(args: Array<String>) {
         Micronaut.build()
-                .packages("com.coffeeculture")
+                .packages("com.coffeeculture.sources")
                 .mainClass(Application.javaClass)
                 .start()
     }

--- a/src/main/kotlin/com/coffeeculture/sources/config/DatastoreFactory.kt
+++ b/src/main/kotlin/com/coffeeculture/sources/config/DatastoreFactory.kt
@@ -1,0 +1,57 @@
+package com.coffeeculture.sources.config
+
+import com.coffeeculture.sources.models.data.Roaster
+import com.coffeeculture.sources.repositories.InMemoryRoasterRepository
+import com.coffeeculture.sources.repositories.RoasterRepository
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.micronaut.context.annotation.Bean
+import io.micronaut.context.annotation.Factory
+import io.micronaut.core.io.ResourceLoader
+import io.micronaut.discovery.event.ServiceStartedEvent
+import io.micronaut.runtime.event.annotation.EventListener
+import javax.inject.Singleton
+import org.slf4j.LoggerFactory
+
+@Factory
+class DatastoreFactory(
+    private val mapper: ObjectMapper,
+    private val resourceLoader: ResourceLoader
+) {
+
+    private val logger = LoggerFactory.getLogger(this.javaClass)
+    private lateinit var roasterRepository: RoasterRepository
+
+    companion object {
+        private const val DATA_FILE_URL = "classpath:data/roasters.json"
+    }
+
+    // Initialize the in memory datastore on app startup
+    @EventListener
+    fun init(event: ServiceStartedEvent) {
+        roasterRepository = InMemoryRoasterRepository(getDatastore())
+    }
+
+    @Singleton
+    @Bean
+    fun roasterRepository(): RoasterRepository {
+        return roasterRepository
+    }
+
+    fun getDatastore(): Map<String, Roaster> {
+        val data = readDataFile(DATA_FILE_URL)
+        logger.info("Initializing in memory datastore with ${data.size} roasters")
+
+        return data.map {
+            it.id to it
+        }.toMap()
+    }
+
+    // There's some cleanup that could be done here, but as this is a not the long-term data store, it will work as is.
+    fun readDataFile(fileName: String): List<Roaster> {
+        val inputStream = resourceLoader.getResourceAsStream(fileName).orElseThrow()
+        val typeReference = object : TypeReference<List<Roaster>>() {}
+
+        return mapper.readValue(inputStream, typeReference)
+    }
+}

--- a/src/main/kotlin/com/coffeeculture/sources/config/JacksonConfig.kt
+++ b/src/main/kotlin/com/coffeeculture/sources/config/JacksonConfig.kt
@@ -1,0 +1,26 @@
+package com.coffeeculture.sources.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.micronaut.context.annotation.Bean
+import io.micronaut.context.annotation.Factory
+import javax.inject.Singleton
+
+@Factory
+class JacksonConfig {
+
+    /*
+        This ObjectMapper configuration is duplicated into the test source set. The configurations must be kept
+        consistent or tests may not provide adequate coverage. Ideally, this bean would be defined in a common project
+        that shares such configurations across all of the source sets.
+     */
+    @Singleton
+    @Bean
+    fun getObjectMapper(): ObjectMapper {
+        return jacksonObjectMapper()
+            .registerModule(JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    }
+}

--- a/src/main/kotlin/com/coffeeculture/sources/models/data/Roaster.kt
+++ b/src/main/kotlin/com/coffeeculture/sources/models/data/Roaster.kt
@@ -1,0 +1,29 @@
+package com.coffeeculture.sources.models.data
+
+import java.net.URL
+import java.time.Instant
+
+data class Roaster(
+    val id: String,
+    val name: String,
+    val urls: List<RoasterUrl>,
+    val status: Status = Status.ENABLED,
+    val createdAt: Instant,
+    val updatedAt: Instant? = null,
+    val deletedAt: Instant? = null
+)
+
+enum class Status {
+    ENABLED,
+    DISABLED
+}
+
+data class RoasterUrl(
+    val name: RoasterUrlName,
+    val url: URL
+)
+
+enum class RoasterUrlName {
+    HOME,
+    SCRAPE
+}

--- a/src/main/kotlin/com/coffeeculture/sources/repositories/RoasterRepository.kt
+++ b/src/main/kotlin/com/coffeeculture/sources/repositories/RoasterRepository.kt
@@ -1,0 +1,23 @@
+package com.coffeeculture.sources.repositories
+
+import com.coffeeculture.sources.models.data.Roaster
+import javax.inject.Singleton
+
+interface RoasterRepository {
+    fun find(): List<Roaster>
+    fun findById(id: String): Roaster?
+}
+
+@Singleton
+class InMemoryRoasterRepository(
+    private val data: Map<String, Roaster>
+) : RoasterRepository {
+
+    override fun find(): List<Roaster> {
+        return data.values.toList()
+    }
+
+    override fun findById(id: String): Roaster? {
+        return data[id]
+    }
+}

--- a/src/main/resources/data/roasters.json
+++ b/src/main/resources/data/roasters.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "08fa6ef4-0c64-4635-8a9d-c4ac973c04dc",
+    "name": "Little Wolf Coffee",
+    "urls": [
+      {
+        "name": "HOME",
+        "url": "https://littlewolf.coffee/"
+      },
+      {
+        "name": "SCRAPE",
+        "url": "https://littlewolf.coffee/collections/shop"
+      }
+    ],
+    "status": "DISABLED",
+    "createdAt": "2020-04-18T13:10:53Z"
+  },
+  {
+    "id": "2b8df1e8-6cf5-4cdf-9f84-a819bf23301d",
+    "name": "Flatlands Coffee",
+    "urls": [
+      {
+        "name": "HOME",
+        "url": "https://www.flatlandscoffee.com/"
+      },
+      {
+        "name": "SCRAPE",
+        "url": "https://www.flatlandscoffee.com/shop"
+      }
+    ],
+    "status": "DISABLED",
+    "createdAt": "2020-04-18T13:10:53Z"
+  },
+  {
+    "id": "f25a57d2-093c-43f0-b4d8-a2da75ef6ad0",
+    "name": "Counter Culture Coffee",
+    "urls": [
+      {
+        "name": "HOME",
+        "url": "https://counterculturecoffee.com/"
+      },
+      {
+        "name": "SCRAPE",
+        "url": "https://counterculturecoffee.com/shop/category/coffee"
+      }
+    ],
+    "status": "DISABLED",
+    "createdAt": "2020-04-18T13:10:53Z"
+  },
+  {
+    "id": "b1c73bd3-72ba-4b4b-aef2-68bd9149ee84",
+    "name": "Verve Coffee Roasters",
+    "urls": [
+      {
+        "name": "HOME",
+        "url": "https://www.vervecoffee.com/"
+      },
+      {
+        "name": "SCRAPE",
+        "url": "https://www.vervecoffee.com/collections/all-coffee"
+      }
+    ],
+    "status": "DISABLED",
+    "createdAt": "2020-04-18T13:10:53Z"
+  },
+  {
+    "id": "56d2464e-f784-44ca-ad0b-eec19659a32a",
+    "name": "Scratch Living Coffee",
+    "urls": [
+      {
+        "name": "HOME",
+        "url": "https://www.fromscratchliving.com/"
+      },
+      {
+        "name": "SCRAPE",
+        "url": "https://www.fromscratchliving.com/shop"
+      }
+    ],
+    "status": "DISABLED",
+    "createdAt": "2020-04-18T13:10:53Z"
+  },
+  {
+    "id": "bd4d5dac-ca1b-498c-84c1-f6a24bf36571",
+    "name": "Sweet Bloom Coffee Roasters",
+    "urls": [
+      {
+        "name": "HOME",
+        "url": "https://sweetbloomcoffee.com/"
+      },
+      {
+        "name": "SCRAPE",
+        "url": "https://sweetbloomcoffee.com/collections/coffee"
+      }
+    ],
+    "status": "DISABLED",
+    "createdAt": "2020-04-18T13:10:53Z"
+  }
+]

--- a/src/test/kotlin/com/coffeeculture/sources/common/JacksonConfig.kt
+++ b/src/test/kotlin/com/coffeeculture/sources/common/JacksonConfig.kt
@@ -1,0 +1,20 @@
+package com.coffeeculture.sources.common
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+
+object JacksonConfig {
+
+    /*
+        This ObjectMapper configuration is duplicated from the main source set. The configurations must be kept
+        consistent or tests may not provide adequate coverage. Ideally, this bean would be defined in a common project
+        that shares such configurations across all of the source sets.
+     */
+    fun getObjectMapper(): ObjectMapper {
+        return jacksonObjectMapper()
+            .registerModule(JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    }
+}

--- a/src/test/kotlin/com/coffeeculture/sources/common/Roasters.kt
+++ b/src/test/kotlin/com/coffeeculture/sources/common/Roasters.kt
@@ -1,0 +1,29 @@
+package com.coffeeculture.sources.common
+
+import com.coffeeculture.sources.models.data.Roaster
+import com.coffeeculture.sources.models.data.RoasterUrl
+import com.coffeeculture.sources.models.data.RoasterUrlName
+import com.coffeeculture.sources.models.data.Status
+import java.net.URL
+import java.time.Instant
+
+object Roasters {
+    fun littleWolfCoffee(): Roaster {
+        return Roaster(
+            id = "08fa6ef4-0c64-4635-8a9d-c4ac973c04dc",
+            name = "Little Wolf Coffee",
+            status = Status.DISABLED,
+            urls = listOf(
+                RoasterUrl(
+                    name = RoasterUrlName.HOME,
+                    url = URL("https://littlewolf.coffee/")
+                ),
+                RoasterUrl(
+                    name = RoasterUrlName.SCRAPE,
+                    url = URL("https://littlewolf.coffee/collections/shop")
+                )
+            ),
+            createdAt = Instant.parse("2020-04-18T13:10:53Z")
+        )
+    }
+}

--- a/src/test/kotlin/com/coffeeculture/sources/config/DatastoreFactorySpec.kt
+++ b/src/test/kotlin/com/coffeeculture/sources/config/DatastoreFactorySpec.kt
@@ -1,0 +1,42 @@
+package com.coffeeculture.sources.config
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.coffeeculture.sources.common.JacksonConfig
+import com.coffeeculture.sources.common.Roasters
+import io.micronaut.core.io.scan.DefaultClassPathResourceLoader
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object DatastoreFactorySpec : Spek({
+    describe("DatastoreFactory") {
+        // If the InMemoryDataStore were not a temp solution, I'd turn this into an integration test and inject both
+        // the ResourceLoader and ObjectMapper.
+        val mapper = JacksonConfig.getObjectMapper()
+        val resourceLoader = DefaultClassPathResourceLoader(this.javaClass.classLoader)
+        val datastoreFactory = DatastoreFactory(mapper, resourceLoader)
+
+        describe("#getDatastore") {
+            val datastore = datastoreFactory.getDatastore()
+
+            it("returns a collection containing 6 coffee roasters") {
+                assertThat(datastore.size).isEqualTo(6)
+            }
+
+            it("deserializes roaster from data file") {
+                val result = datastore["08fa6ef4-0c64-4635-8a9d-c4ac973c04dc"]
+                val expected = Roasters.littleWolfCoffee()
+
+                assertThat(result).isEqualTo(expected)
+            }
+        }
+
+        describe("#readDataFile") {
+            it("reads roasters from json file") {
+                val roasters = datastoreFactory.readDataFile("classpath:data/roasters.json")
+
+                assertThat(roasters.size).isEqualTo(6)
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/coffeeculture/sources/repositories/InMemoryRoasterRepositorySpec.kt
+++ b/src/test/kotlin/com/coffeeculture/sources/repositories/InMemoryRoasterRepositorySpec.kt
@@ -1,0 +1,45 @@
+package com.coffeeculture.sources.repositories
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import com.coffeeculture.sources.common.JacksonConfig
+import com.coffeeculture.sources.common.Roasters
+import com.coffeeculture.sources.config.DatastoreFactory
+import io.micronaut.core.io.scan.DefaultClassPathResourceLoader
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object InMemoryRoasterRepositorySpec : Spek({
+
+    describe("InMemoryRoasterRepository") {
+        val mapper = JacksonConfig.getObjectMapper()
+        val resourceLoader = DefaultClassPathResourceLoader(this.javaClass.classLoader)
+
+        val datastoreFactory = DatastoreFactory(mapper, resourceLoader)
+        val repository = InMemoryRoasterRepository(datastoreFactory.getDatastore())
+
+        describe("#find") {
+            it("returns 6 roasters") {
+                val result = repository.find()
+
+                assertThat(result.size).isEqualTo(6)
+            }
+        }
+
+        describe("#findById") {
+            it("returns expected roaster") {
+                val result = repository.findById("08fa6ef4-0c64-4635-8a9d-c4ac973c04dc")
+                val expected = Roasters.littleWolfCoffee()
+
+                assertThat(result).isEqualTo(expected)
+            }
+
+            it("returns null when roaster does not exist") {
+                val result = repository.findById("invalid-id")
+
+                assertThat(result).isNull()
+            }
+        }
+    }
+})

--- a/src/test/resources/data/roasters.json
+++ b/src/test/resources/data/roasters.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "08fa6ef4-0c64-4635-8a9d-c4ac973c04dc",
+    "name": "Little Wolf Coffee",
+    "urls": [
+      {
+        "name": "HOME",
+        "url": "https://littlewolf.coffee/"
+      },
+      {
+        "name": "SCRAPE",
+        "url": "https://littlewolf.coffee/collections/shop"
+      }
+    ],
+    "status": "DISABLED",
+    "createdAt": "2020-04-18T13:10:53Z"
+  },
+  {
+    "id": "2b8df1e8-6cf5-4cdf-9f84-a819bf23301d",
+    "name": "Flatlands Coffee",
+    "urls": [
+      {
+        "name": "HOME",
+        "url": "https://www.flatlandscoffee.com/"
+      },
+      {
+        "name": "SCRAPE",
+        "url": "https://www.flatlandscoffee.com/shop"
+      }
+    ],
+    "status": "DISABLED",
+    "createdAt": "2020-04-18T13:10:53Z"
+  },
+  {
+    "id": "f25a57d2-093c-43f0-b4d8-a2da75ef6ad0",
+    "name": "Counter Culture Coffee",
+    "urls": [
+      {
+        "name": "HOME",
+        "url": "https://counterculturecoffee.com/"
+      },
+      {
+        "name": "SCRAPE",
+        "url": "https://counterculturecoffee.com/shop/category/coffee"
+      }
+    ],
+    "status": "DISABLED",
+    "createdAt": "2020-04-18T13:10:53Z"
+  },
+  {
+    "id": "b1c73bd3-72ba-4b4b-aef2-68bd9149ee84",
+    "name": "Verve Coffee Roasters",
+    "urls": [
+      {
+        "name": "HOME",
+        "url": "https://www.vervecoffee.com/"
+      },
+      {
+        "name": "SCRAPE",
+        "url": "https://www.vervecoffee.com/collections/all-coffee"
+      }
+    ],
+    "status": "DISABLED",
+    "createdAt": "2020-04-18T13:10:53Z"
+  },
+  {
+    "id": "56d2464e-f784-44ca-ad0b-eec19659a32a",
+    "name": "Scratch Living Coffee",
+    "urls": [
+      {
+        "name": "HOME",
+        "url": "https://www.fromscratchliving.com/"
+      },
+      {
+        "name": "SCRAPE",
+        "url": "https://www.fromscratchliving.com/shop"
+      }
+    ],
+    "status": "DISABLED",
+    "createdAt": "2020-04-18T13:10:53Z"
+  },
+  {
+    "id": "bd4d5dac-ca1b-498c-84c1-f6a24bf36571",
+    "name": "Sweet Bloom Coffee Roasters",
+    "urls": [
+      {
+        "name": "HOME",
+        "url": "https://sweetbloomcoffee.com/"
+      },
+      {
+        "name": "SCRAPE",
+        "url": "https://sweetbloomcoffee.com/collections/coffee"
+      }
+    ],
+    "status": "DISABLED",
+    "createdAt": "2020-04-18T13:10:53Z"
+  }
+]


### PR DESCRIPTION
This commit adds a first take at the Roaster/Source model. This model is a work in progress. For now, this data will very infrequently change and will be supported by an in memory datastore that is initialized from a JSON file at startup. This will be refactored to be backed by a different datastore once this model is more firm.