### PR TITLE
fix: move Application.kt to sources package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
 
 test.classpath += configurations.developmentOnly
 
-mainClassName = "com.coffeeculture.Application"
+mainClassName = "com.coffeeculture.sources.Application"
 
 test {
     useJUnitPlatform()

--- a/src/main/kotlin/com/coffeeculture/sources/Application.kt
+++ b/src/main/kotlin/com/coffeeculture/sources/Application.kt
@@ -1,4 +1,4 @@
-package com.coffeeculture
+package com.coffeeculture.sources
 
 import io.micronaut.runtime.Micronaut
 


### PR DESCRIPTION
This commit resolves a mixup with the initial project structure that omitted the `sources` package. This incorrectly left `com.coffeeculture` as the project root package. 